### PR TITLE
Fix build: pin PHP to 8.4 for mpdf compatibility

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.railpack.com",
   "packages": {
-    "php": "8.3"
+    "php": "8.4"
   }
 }
+


### PR DESCRIPTION
## Problem\nThe build fails during  because Railpack auto-resolved PHP 8.5.7, but  is incompatible with PHP 8.5:\n- mpdf v8.2.0–v8.2.5 require PHP ≤8.4 ( max)\n- mpdf v8.2.6–v8.3.1 require  which is missing from the build image\n\nBuild error:\n\n\n## Solution\nPin PHP to 8.4 via . This allows Composer to resolve , which explicitly supports  and does not require the  extension.\n\nPrevents Railpack from auto-resolving to PHP 8.5+ where no compatible mpdf version exists without the gd extension.

## Summary by Sourcery

Build:
- Set Railpack PHP runtime to 8.4 to avoid auto-resolving to incompatible PHP 8.5+ versions.